### PR TITLE
Task >> create provider

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -64,36 +64,38 @@ function App(): React.JSX.Element {
   };
 
   return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar
-        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-        backgroundColor={backgroundStyle.backgroundColor}
-      />
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={backgroundStyle}>
-        <Header />
-        <View
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-          }}>
-          <Section title="Step One">
-            Edit <Text style={styles.highlight}>App.tsx</Text> to change this
-            screen and then come back to see your edits.
-          </Section>
-          <Section title="See Your Changes">
-            <ReloadInstructions />
-          </Section>
-          <Section title="Debug">
-            <DebugInstructions />
-          </Section>
-          <Section title="Learn More">
-            Read the docs to discover what to do next:
-          </Section>
-          <LearnMoreLinks />
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+    <KomojuSDK.KomojouProvider urlScheme="" pubickKey="">
+      <SafeAreaView style={backgroundStyle}>
+        <StatusBar
+          barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+          backgroundColor={backgroundStyle.backgroundColor}
+        />
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          style={backgroundStyle}>
+          <Header />
+          <View
+            style={{
+              backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            }}>
+            <Section title="Step One">
+              Edit <Text style={styles.highlight}>App.tsx</Text> to change this
+              screen and then come back to see your edits.
+            </Section>
+            <Section title="See Your Changes">
+              <ReloadInstructions />
+            </Section>
+            <Section title="Debug">
+              <DebugInstructions />
+            </Section>
+            <Section title="Learn More">
+              Read the docs to discover what to do next:
+            </Section>
+            <LearnMoreLinks />
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </KomojuSDK.KomojouProvider>
   );
 }
 

--- a/payment_sdk/package.json
+++ b/payment_sdk/package.json
@@ -13,6 +13,7 @@
     "@babel/preset-env": "^7.24.6",
     "@babel/preset-react": "^7.24.6",
     "@babel/preset-typescript": "^7.24.6",
+    "@types/react": "^18.3.3",
     "eslint": "^9.3.0",
     "jest": "^29.7.0",
     "react": "18.2.0",

--- a/payment_sdk/src/KomojuProvider.tsx
+++ b/payment_sdk/src/KomojuProvider.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode, useCallback, useMemo, useState } from "react";
+import { View } from "react-native";
+
+import { noop } from "./util/constants";
+import { InitPrams, KomojuContext as KomjouContextType } from "./util/types";
+
+const defaultValue = {
+  createPayment: noop,
+  showPaymentSheetUI: noop,
+  initializeKomoju: noop,
+};
+export const KomojuContext =
+  React.createContext<KomjouContextType>(defaultValue);
+
+type KomojuProviderIprops = {
+  children?: ReactNode | ReactNode[];
+} & InitPrams;
+
+export const KomojuProvider = (props: KomojuProviderIprops) => {
+  const [showPaymentSheet, setShowPaymentSheet] = useState(false);
+  const [komojuState, setKomojuState] = useState<InitPrams>({});
+
+  const createPayment = useCallback(() => {
+    // here call the session pay
+    // take params from state or props
+  }, []);
+
+  const showPaymentSheetUI = useCallback(() => {
+    // take params from state or props
+  }, []);
+  const initializeKomoju = useCallback((params: InitPrams) => {}, []);
+
+  const renderPaymentUI = useMemo(() => {
+    const UI = showPaymentSheet ? <View /> : null;
+    return UI;
+  }, []);
+
+  return (
+    <KomojuContext.Provider
+      value={{ createPayment, showPaymentSheetUI, initializeKomoju }}
+    >
+      {props.children}
+      {renderPaymentUI}
+    </KomojuContext.Provider>
+  );
+};

--- a/payment_sdk/src/index.ts
+++ b/payment_sdk/src/index.ts
@@ -1,3 +1,10 @@
+import { useContext } from "react";
 import { View } from "react-native";
 
-export const KomojuSDK = {};
+import { KomojuContext, KomojuProvider } from "./KomojuProvider";
+
+export const KomojuSDK = {
+  useKomoju: () => useContext(KomojuContext), // for functional components use this
+  komjouConsumer: KomojuContext.Consumer, // for class components use this
+  KomojouProvider: KomojuProvider, // wrap the react native entry point with this
+};

--- a/payment_sdk/src/services/baseService.ts
+++ b/payment_sdk/src/services/baseService.ts
@@ -1,0 +1,1 @@
+// add the base API here using fetch

--- a/payment_sdk/src/services/paymentService.ts
+++ b/payment_sdk/src/services/paymentService.ts
@@ -1,0 +1,1 @@
+// create payments must be implmented here

--- a/payment_sdk/src/util/constants.ts
+++ b/payment_sdk/src/util/constants.ts
@@ -1,0 +1,2 @@
+export const noop = () => {};
+const BASE_URL = ""; // add base URL here

--- a/payment_sdk/src/util/types.ts
+++ b/payment_sdk/src/util/types.ts
@@ -1,0 +1,16 @@
+export type InitPrams = {
+  urlScheme: string;
+  pubickKey: string;
+};
+
+export type createPaymentFuncType = (
+  sessionId: string,
+  onError: () => {}, // define the callback types here
+  onSuccess?: () => {} // define the callback types here
+) => {};
+
+export type KomojuContext = {
+  createPayment: () => void; // add the types for here
+  showPaymentSheetUI: () => void;
+  initializeKomoju: (args: InitPrams) => void;
+};


### PR DESCRIPTION
This PR add the **KomojuProvider** context and few other util , types modules. Komoju context will be used to pass public key and url scheme from the client application.  KomojuProvider has three methods  **createPayment, showPaymentSheetUI, initializeKomoju**  these are exposed to client app side 

createPayment method >> this is used to create the session payment. This accepts sessionId , successCallback and errorCallBack
showPaymentSheetUI >> If the client app want to show the payment UI explicitly this method can be used 
 initializeKomoju >> This method can be used to pass and initialize  return url and publick key. If the publick key is generated dynamically. This method will be the ideal.
 
Client app should wrap the App.tsx with the KomojuProvider. 
Client app can access KomojuProvider methods using hooks (**_useKomoju_**) or komjouConsumer (this is ideal for class components) 
