### PR TITLE
[MOB-6] Tag HTTP requests with KOMOJU-VIA

### DIFF
--- a/payment_sdk/src/services/payForSessionService.ts
+++ b/payment_sdk/src/services/payForSessionService.ts
@@ -1,4 +1,4 @@
-import { BASE_URL_API } from "../util/constants";
+import { API_HEADER, BASE_URL_API } from "../util/constants";
 import { getMonthYearFromExpiry, printLog } from "../util/helpers";
 import {
   payForSessionProps,
@@ -79,11 +79,7 @@ const payForSession = async ({
     // payment POST request options of headers and body should be as bellow
     const options = {
       method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-        Authorization: `Basic ${btoa(publicKey + ":")}`,
-      },
+      headers: API_HEADER(publicKey),
       body: JSON.stringify({
         capture: "auto",
         payment_details,

--- a/payment_sdk/src/services/sessionShow.ts
+++ b/payment_sdk/src/services/sessionShow.ts
@@ -1,4 +1,4 @@
-import { BASE_URL_API } from "../util/constants";
+import { API_HEADER, BASE_URL_API } from "../util/constants";
 import { printLog } from "../util/helpers";
 import { SessionShowResponseType } from "../util/types";
 
@@ -15,10 +15,7 @@ const sessionShow = async ({
     const url = `${BASE_URL_API}/sessions/${sessionId}`;
     const options = {
       method: "GET",
-      headers: {
-        accept: "application/json",
-        Authorization: `Basic ${btoa(publicKey + ":")}`,
-      },
+      headers: API_HEADER(publicKey),
     };
 
     const response = await fetch(url, options);

--- a/payment_sdk/src/util/constants.ts
+++ b/payment_sdk/src/util/constants.ts
@@ -1,6 +1,12 @@
 export const noop = () => {};
 export const BASE_URL = "https://komoju.com";
 export const BASE_URL_API = `${BASE_URL}/api/v1`;
+export const API_HEADER = (publicKey: string) => ({
+  accept: "application/json",
+  "content-type": "application/json",
+  "KOMOJU-VIA": "mobile_react",
+  Authorization: `Basic ${btoa(publicKey + ":")}`,
+});
 
 export const STATIC_CREDIT_CARD_SVG =
   "https://komoju-fields-demo.herokuapp.com/static/credit_card_number.svg";


### PR DESCRIPTION
Using KOMOJU-VIA: mobile_react in request headers to KOMOJU API to track which SDK payment requests originate from