### PR TITLE
Add tsc-alias to the payment_sdk package

### DIFF
--- a/payment_sdk/package.json
+++ b/payment_sdk/package.json
@@ -55,6 +55,7 @@
     "react-native": "0.74.1",
     "react-test-renderer": "^18.2.0",
     "ts-jest": "^29.1.4",
+    "tsc-alias": "^1.8.10",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.12.0"
   },


### PR DESCRIPTION
### Context

I noticed that `tsc-alias` is used for `build:types` script but is not included in the project.