### PR TITLE
Use white for input fields and background

### DIFF
--- a/payment_sdk/src/theme/defaultColorTheme.ts
+++ b/payment_sdk/src/theme/defaultColorTheme.ts
@@ -17,10 +17,10 @@ const darkTheme = {
 
 const lightTheme = {
     PRIMARY_COLOR: "#0B82EE",
-    BACKGROUND_COLOR: "#FBFBFB",
+    BACKGROUND_COLOR: "#FFFFFF",
     ERROR: "#fc5d5d",
     TEXT_COLOR: "#172E44",
-    INPUT_BACKGROUND: '#F7F8F8',
+    INPUT_BACKGROUND: '#FFFFFF',
     INPUT_TEXT: '#172E44',
     INPUT_PLACEHOLDER: '#ADA4A5',
     INVERTED_CONTENT: '#fff',


### PR DESCRIPTION
## Context

The original design used white background and input fields. This change alters the light theme to match the original design.